### PR TITLE
Add practice questions card to chapter page

### DIFF
--- a/src/components/ChapterList.js
+++ b/src/components/ChapterList.js
@@ -44,13 +44,13 @@ function ChapterList() {
       
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {course.chapters.map((chapter) => (
-          <div 
-            key={chapter.id} 
+          <div
+            key={chapter.id}
             className="bg-white rounded-lg shadow-md overflow-hidden transition-transform duration-300 hover:shadow-lg hover:scale-105"
           >
             <div className="p-6">
               <h2 className="text-xl font-semibold mb-4">{chapter.title}</h2>
-              <Link 
+              <Link
                 to={`/courses/${encodeURIComponent(course.title)}/chapters/${encodeURIComponent(chapter.title)}`}
                 className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded transition-colors duration-300"
               >
@@ -59,6 +59,18 @@ function ChapterList() {
             </div>
           </div>
         ))}
+
+        <div className="bg-white rounded-lg shadow-md overflow-hidden transition-transform duration-300 hover:shadow-lg hover:scale-105">
+          <div className="p-6">
+            <h2 className="text-xl font-semibold mb-4">{textContent.chapterList.practiceQuestions}</h2>
+            <Link
+              to={`/courses/${encodeURIComponent(course.title)}/practice-questions`}
+              className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded transition-colors duration-300"
+            >
+              {textContent.chapterList.startPractice}
+            </Link>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/PracticeQuestions.js
+++ b/src/components/PracticeQuestions.js
@@ -5,7 +5,7 @@ import { textContent } from '../constants/textContent';
 import MCQSection from './MCQSection';
 
 function PracticeQuestions() {
-  const { courseTitle, chapterTitle } = useParams();
+  const { courseTitle } = useParams();
   const navigate = useNavigate();
 
   // Find the course by title
@@ -29,40 +29,21 @@ function PracticeQuestions() {
     );
   }
 
-  // Find the chapter by title
-  const chapter = course.chapters.find(ch =>
-    ch.title.toLowerCase() === decodeURIComponent(chapterTitle).toLowerCase()
+  // Gather all MCQs from all chapters and topics
+  const mcqs = course.chapters.flatMap(chapter =>
+    chapter.topics.flatMap(topic => topic.mcqs || [])
   );
-
-  // Handle chapter not found
-  if (!chapter) {
-    return (
-      <div className="text-center py-10">
-        <h1 className="text-3xl font-bold mb-4">{textContent.errors.notFound}</h1>
-        <p className="mb-6">{textContent.errors.notFoundMessage}</p>
-        <button
-          onClick={() => navigate(`/courses/${encodeURIComponent(course.title)}/chapters`)}
-          className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded"
-        >
-          {textContent.practiceQuestionsPage.backToTopics}
-        </button>
-      </div>
-    );
-  }
-
-  // Gather all MCQs from topics
-  const mcqs = chapter.topics.flatMap(topic => topic.mcqs || []);
 
   return (
     <div>
       <Link
-        to={`/courses/${encodeURIComponent(course.title)}/chapters/${encodeURIComponent(chapter.title)}`}
+        to={`/courses/${encodeURIComponent(course.title)}/chapters`}
         className="inline-flex items-center text-blue-600 hover:text-blue-800 mb-8"
       >
         <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
         </svg>
-        {textContent.practiceQuestionsPage.backToTopics}
+        {textContent.practiceQuestionsPage.backToChapters}
       </Link>
 
       <h1 className="text-3xl font-bold mb-6">{textContent.practiceQuestionsPage.heading}</h1>

--- a/src/components/PracticeQuestions.js
+++ b/src/components/PracticeQuestions.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { courses } from '../data/courseData';
+import { textContent } from '../constants/textContent';
+import MCQSection from './MCQSection';
+
+function PracticeQuestions() {
+  const { courseTitle, chapterTitle } = useParams();
+  const navigate = useNavigate();
+
+  // Find the course by title
+  const course = courses.find(c =>
+    c.title.toLowerCase() === decodeURIComponent(courseTitle).toLowerCase()
+  );
+
+  // Handle course not found
+  if (!course) {
+    return (
+      <div className="text-center py-10">
+        <h1 className="text-3xl font-bold mb-4">{textContent.errors.notFound}</h1>
+        <p className="mb-6">{textContent.errors.notFoundMessage}</p>
+        <button
+          onClick={() => navigate('/courses')}
+          className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded"
+        >
+          {textContent.errors.goHome}
+        </button>
+      </div>
+    );
+  }
+
+  // Find the chapter by title
+  const chapter = course.chapters.find(ch =>
+    ch.title.toLowerCase() === decodeURIComponent(chapterTitle).toLowerCase()
+  );
+
+  // Handle chapter not found
+  if (!chapter) {
+    return (
+      <div className="text-center py-10">
+        <h1 className="text-3xl font-bold mb-4">{textContent.errors.notFound}</h1>
+        <p className="mb-6">{textContent.errors.notFoundMessage}</p>
+        <button
+          onClick={() => navigate(`/courses/${encodeURIComponent(course.title)}/chapters`)}
+          className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded"
+        >
+          {textContent.practiceQuestionsPage.backToTopics}
+        </button>
+      </div>
+    );
+  }
+
+  // Gather all MCQs from topics
+  const mcqs = chapter.topics.flatMap(topic => topic.mcqs || []);
+
+  return (
+    <div>
+      <Link
+        to={`/courses/${encodeURIComponent(course.title)}/chapters/${encodeURIComponent(chapter.title)}`}
+        className="inline-flex items-center text-blue-600 hover:text-blue-800 mb-8"
+      >
+        <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+        </svg>
+        {textContent.practiceQuestionsPage.backToTopics}
+      </Link>
+
+      <h1 className="text-3xl font-bold mb-6">{textContent.practiceQuestionsPage.heading}</h1>
+
+      {mcqs.length > 0 ? (
+        <MCQSection mcqs={mcqs} />
+      ) : (
+        <p>{textContent.practiceQuestionsPage.noQuestions}</p>
+      )}
+    </div>
+  );
+}
+
+export default PracticeQuestions;

--- a/src/components/TopicList.js
+++ b/src/components/TopicList.js
@@ -63,16 +63,16 @@ function TopicList() {
       
       <h1 className="text-3xl font-bold mb-2">{chapter.title}</h1>
       <h2 className="text-xl text-gray-600 mb-6">{textContent.topicList.heading}</h2>
-      
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {chapter.topics.map((topic) => (
-          <div 
-            key={topic.id} 
+          <div
+            key={topic.id}
             className="bg-white rounded-lg shadow-md overflow-hidden transition-transform duration-300 hover:shadow-lg hover:scale-105"
           >
             <div className="p-6">
               <h3 className="text-lg font-semibold mb-4">{topic.title}</h3>
-              <Link 
+              <Link
                 to={`/courses/${encodeURIComponent(course.title)}/chapters/${encodeURIComponent(chapter.title)}/topics/${encodeURIComponent(topic.title)}`}
                 className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded transition-colors duration-300"
               >
@@ -81,6 +81,18 @@ function TopicList() {
             </div>
           </div>
         ))}
+
+        <div className="bg-white rounded-lg shadow-md overflow-hidden transition-transform duration-300 hover:shadow-lg hover:scale-105">
+          <div className="p-6">
+            <h3 className="text-lg font-semibold mb-4">{textContent.topicList.practiceQuestions}</h3>
+            <Link
+              to={`/courses/${encodeURIComponent(course.title)}/chapters/${encodeURIComponent(chapter.title)}/practice-questions`}
+              className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded transition-colors duration-300"
+            >
+              {textContent.topicList.startPractice}
+            </Link>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/TopicList.js
+++ b/src/components/TopicList.js
@@ -81,18 +81,6 @@ function TopicList() {
             </div>
           </div>
         ))}
-
-        <div className="bg-white rounded-lg shadow-md overflow-hidden transition-transform duration-300 hover:shadow-lg hover:scale-105">
-          <div className="p-6">
-            <h3 className="text-lg font-semibold mb-4">{textContent.topicList.practiceQuestions}</h3>
-            <Link
-              to={`/courses/${encodeURIComponent(course.title)}/chapters/${encodeURIComponent(chapter.title)}/practice-questions`}
-              className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded transition-colors duration-300"
-            >
-              {textContent.topicList.startPractice}
-            </Link>
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/src/constants/textContent.js
+++ b/src/constants/textContent.js
@@ -18,7 +18,7 @@ export const textContent = {
     courseDetails: {
       syllabus: "Syllabus",
       modelPaper: "Model Question Paper",
-      chapters: "Chapters",
+      chapters: "Chapterwise Study Material",
       back: "Back to Courses",
     },
     chapterList: {

--- a/src/constants/textContent.js
+++ b/src/constants/textContent.js
@@ -28,6 +28,8 @@ export const textContent = {
     topicList: {
       heading: "Topics",
       backToChapters: "Back to Chapters",
+      practiceQuestions: "Practice Question",
+      startPractice: "Start Practice",
     },
     topicDetails: {
       videos: "Video Lectures",
@@ -36,6 +38,11 @@ export const textContent = {
       questions: "Practice Questions",
       description: "Description",
       backToTopics: "Back to Topics",
+    },
+    practiceQuestionsPage: {
+      heading: "Practice Questions",
+      backToTopics: "Back to Topics",
+      noQuestions: "No practice questions available.",
     },
     mcq: {
       showAnswer: "Show Answer",

--- a/src/constants/textContent.js
+++ b/src/constants/textContent.js
@@ -24,12 +24,12 @@ export const textContent = {
     chapterList: {
       heading: "Chapters",
       backToCourse: "Back to Course",
+      practiceQuestions: "Practice Question",
+      startPractice: "Start Practice",
     },
     topicList: {
       heading: "Topics",
       backToChapters: "Back to Chapters",
-      practiceQuestions: "Practice Question",
-      startPractice: "Start Practice",
     },
     topicDetails: {
       videos: "Video Lectures",
@@ -41,7 +41,7 @@ export const textContent = {
     },
     practiceQuestionsPage: {
       heading: "Practice Questions",
-      backToTopics: "Back to Topics",
+      backToChapters: "Back to Chapters",
       noQuestions: "No practice questions available.",
     },
     mcq: {
@@ -56,5 +56,5 @@ export const textContent = {
       goHome: "Go Home",
     }
   };
-  
-  export default textContent;
+
+export default textContent;

--- a/src/routes/AppRoutes.js
+++ b/src/routes/AppRoutes.js
@@ -5,6 +5,7 @@ import CourseDetails from '../components/CourseDetails';
 import ChapterList from '../components/ChapterList';
 import TopicList from '../components/TopicList';
 import TopicDetails from '../components/TopicDetails';
+import PracticeQuestions from '../components/PracticeQuestions';
 
 function AppRoutes() {
   return (
@@ -14,6 +15,10 @@ function AppRoutes() {
       <Route path="/courses/:courseTitle" element={<CourseDetails />} />
       <Route path="/courses/:courseTitle/chapters" element={<ChapterList />} />
       <Route path="/courses/:courseTitle/chapters/:chapterTitle" element={<TopicList />} />
+      <Route
+        path="/courses/:courseTitle/chapters/:chapterTitle/practice-questions"
+        element={<PracticeQuestions />}
+      />
       <Route path="/courses/:courseTitle/chapters/:chapterTitle/topics/:topicTitle" element={<TopicDetails />} />
       <Route path="*" element={
         <div className="text-center py-10">

--- a/src/routes/AppRoutes.js
+++ b/src/routes/AppRoutes.js
@@ -16,7 +16,7 @@ function AppRoutes() {
       <Route path="/courses/:courseTitle/chapters" element={<ChapterList />} />
       <Route path="/courses/:courseTitle/chapters/:chapterTitle" element={<TopicList />} />
       <Route
-        path="/courses/:courseTitle/chapters/:chapterTitle/practice-questions"
+        path="/courses/:courseTitle/practice-questions"
         element={<PracticeQuestions />}
       />
       <Route path="/courses/:courseTitle/chapters/:chapterTitle/topics/:topicTitle" element={<TopicDetails />} />


### PR DESCRIPTION
## Summary
- add practice question card to chapter topics page
- new PracticeQuestions component aggregates MCQs for chapter
- wire practice questions route and text content

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_689c24d02c4083308564283635578b05