### PR TITLE
Expand course outlines for NEC disciplines

### DIFF
--- a/public/pdfs/placeholder.pdf
+++ b/public/pdfs/placeholder.pdf
@@ -1,0 +1,1 @@
+Placeholder content

--- a/src/data/courseData.js
+++ b/src/data/courseData.js
@@ -1,3 +1,19 @@
+const defaultChapter = {
+  id: 1,
+  title: "Introduction",
+  topics: [
+    {
+      id: 1,
+      title: "Overview",
+      description: "Study materials will be added soon.",
+      videos: [],
+      pdfs: [],
+      externalLinks: [],
+      mcqs: [],
+    },
+  ],
+};
+
 export const courses = [
   {
     "id": 1,
@@ -184,6 +200,378 @@ export const courses = [
       }
     ]
   },
-  ];
-  
-  export default courses;
+  {
+    id: 2,
+    title: "Civil Engineering",
+    description: "Core concepts of civil engineering for the NEC exam.",
+    image: "https://via.placeholder.com/400x200?text=Civil+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [
+      {
+        id: 1,
+        title: "Engineering Materials",
+        topics: [
+          {
+            id: 1,
+            title: "Cement and Concrete",
+            description: "Types, properties and uses of cement and concrete.",
+            videos: [],
+            pdfs: [
+              { id: 1, title: "Cement Basics", url: "/pdfs/placeholder.pdf" }
+            ],
+            externalLinks: [],
+            mcqs: [
+              {
+                id: 1,
+                question: "Which ingredient of cement contributes to strength?",
+                options: ["Lime", "Silica", "Alumina", "Gypsum"],
+                correctAnswer: "Lime",
+                explanation: "Lime (CaO) imparts strength and soundness to cement."
+              }
+            ]
+          },
+          {
+            id: 2,
+            title: "Steel and Timber",
+            description: "Properties and applications of structural steel and timber.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      },
+      {
+        id: 2,
+        title: "Structural Analysis",
+        topics: [
+          {
+            id: 1,
+            title: "Stress and Strain",
+            description: "Basic concepts of stress, strain and elastic constants.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          },
+          {
+            id: 2,
+            title: "Bending Moment Diagram",
+            description: "Shear force and bending moment calculations for beams.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      }
+    ],
+  },
+  {
+    id: 3,
+    title: "Architecture",
+    description: "Fundamentals of architecture and building design.",
+    image: "https://via.placeholder.com/400x200?text=Architecture",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [
+      {
+        id: 1,
+        title: "Principles of Design",
+        topics: [
+          {
+            id: 1,
+            title: "Design Elements",
+            description: "Line, shape, texture and color in architectural design.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          },
+          {
+            id: 2,
+            title: "Building Orientation",
+            description: "Climate responsive building orientation principles.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      },
+      {
+        id: 2,
+        title: "Building Materials",
+        topics: [
+          {
+            id: 1,
+            title: "Sustainable Materials",
+            description: "Overview of eco-friendly building materials.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      }
+    ],
+  },
+  {
+    id: 4,
+    title: "Electrical Engineering",
+    description: "Electrical engineering principles and practices.",
+    image: "https://via.placeholder.com/400x200?text=Electrical+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [
+      {
+        id: 1,
+        title: "Circuit Theory",
+        topics: [
+          {
+            id: 1,
+            title: "Kirchhoff's Laws",
+            description: "Application of KCL and KVL in electric circuits.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          },
+          {
+            id: 2,
+            title: "AC Fundamentals",
+            description: "Sinusoidal waveforms and phasor representation.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      },
+      {
+        id: 2,
+        title: "Machines and Power",
+        topics: [
+          {
+            id: 1,
+            title: "Transformers",
+            description: "Working principle of single phase transformers.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          },
+          {
+            id: 2,
+            title: "Synchronous Machines",
+            description: "Construction and operation of synchronous generators.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      }
+    ],
+  },
+  {
+    id: 5,
+    title: "Electronics & Communication Engineering",
+    description: "Electronics and communication systems for the NEC exam.",
+    image: "https://via.placeholder.com/400x200?text=Electronics+%26+Communication",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [
+      {
+        id: 1,
+        title: "Analog Electronics",
+        topics: [
+          {
+            id: 1,
+            title: "Amplifiers",
+            description: "Classification and frequency response of amplifiers.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          },
+          {
+            id: 2,
+            title: "Oscillators",
+            description: "Barkhausen criterion and common oscillator circuits.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      },
+      {
+        id: 2,
+        title: "Digital Communication",
+        topics: [
+          {
+            id: 1,
+            title: "Modulation Techniques",
+            description: "ASK, FSK and PSK modulation schemes.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      }
+    ],
+  },
+  {
+    id: 6,
+    title: "Mechanical Engineering",
+    description: "Mechanical engineering topics and design.",
+    image: "https://via.placeholder.com/400x200?text=Mechanical+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [
+      {
+        id: 1,
+        title: "Thermodynamics",
+        topics: [
+          {
+            id: 1,
+            title: "First Law",
+            description: "Energy conservation in closed and open systems.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          },
+          {
+            id: 2,
+            title: "Second Law",
+            description: "Entropy and Carnot efficiency.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      },
+      {
+        id: 2,
+        title: "Fluid Mechanics",
+        topics: [
+          {
+            id: 1,
+            title: "Bernoulli's Equation",
+            description: "Energy balance in flowing fluids.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          },
+          {
+            id: 2,
+            title: "Flow Measurement",
+            description: "Venturimeter and orifice meter principles.",
+            videos: [],
+            pdfs: [],
+            externalLinks: [],
+            mcqs: []
+          }
+        ]
+      }
+    ],
+  },
+  {
+    id: 7,
+    title: "Industrial & Manufacturing Engineering",
+    description: "Industrial processes and manufacturing systems.",
+    image: "https://via.placeholder.com/400x200?text=Industrial+%26+Manufacturing",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 8,
+    title: "Agricultural Engineering",
+    description: "Engineering solutions for agriculture.",
+    image: "https://via.placeholder.com/400x200?text=Agricultural+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 9,
+    title: "Chemical Engineering",
+    description: "Chemical processes and technologies.",
+    image: "https://via.placeholder.com/400x200?text=Chemical+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 10,
+    title: "Biomedical Engineering",
+    description: "Medical devices and biological engineering.",
+    image: "https://via.placeholder.com/400x200?text=Biomedical+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 11,
+    title: "Geomatics/Survey Engineering",
+    description: "Surveying and geomatics technologies.",
+    image: "https://via.placeholder.com/400x200?text=Geomatics+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 12,
+    title: "Hydropower/Water Resources Engineering",
+    description: "Hydropower and water resource management.",
+    image: "https://via.placeholder.com/400x200?text=Hydropower+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 13,
+    title: "Environmental Engineering",
+    description: "Environmental protection and sustainability.",
+    image: "https://via.placeholder.com/400x200?text=Environmental+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 14,
+    title: "Mining Engineering",
+    description: "Exploration and extraction of minerals.",
+    image: "https://via.placeholder.com/400x200?text=Mining+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 15,
+    title: "Automobile Engineering",
+    description: "Design and development of automobiles.",
+    image: "https://via.placeholder.com/400x200?text=Automobile+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+  {
+    id: 16,
+    title: "Metallurgical Engineering",
+    description: "Metals and material science engineering.",
+    image: "https://via.placeholder.com/400x200?text=Metallurgical+Engineering",
+    syllabusLink: "/pdfs/placeholder.pdf",
+    modelQuestionPaperLink: "/pdfs/placeholder.pdf",
+    chapters: [defaultChapter],
+  },
+];
+
+export default courses;


### PR DESCRIPTION
## Summary
- provide civil engineering chapters on materials and structural analysis
- add architecture design principles and building material topics
- extend electrical, electronics & communication, and mechanical courses with basic outlines

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_689c2c15d6e48330b52f914252d110b0